### PR TITLE
Fix 010 showing at 10 mins/secs past the hour/min

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = (function () {
 
     return format('{}/{}/{} {}:{}:{}',
               x.getFullYear(), x.getMonth() + 1, x.getDate(), x.getHours(),
-              m > 10 ? m : '0' + m, s > 10 ? s : '0' + s);
+              m >= 10 ? m : '0' + m, s >= 10 ? s : '0' + s);
   }
 
   function stringifyArgs (args) {


### PR DESCRIPTION
An extra 0 would be added to the minutes or seconds whenever they were at 10 for example:
`[2016/4/18 13:27:010] Info at Server.<anonymous> ...`
